### PR TITLE
Just minor changes to allow viewing atoms from a file lacking a MOOV atom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.old
 *.exe
 videos/
+example/example

--- a/atom/box.go
+++ b/atom/box.go
@@ -105,3 +105,8 @@ func readBoxes(f *File, start int64, n int64) (l []*Box) {
 	}
 	return l
 }
+
+// Stupid, but necessary for my fork of the CLI tool (gwyneth 20191212).
+func ReadBoxes(f *File, start int64, n int64) (l []*Box) {
+	return readBoxes(f, start, n) 
+}

--- a/atom/ftyp.go
+++ b/atom/ftyp.go
@@ -22,3 +22,7 @@ func (b *FtypBox) parse() error {
 	}
 	return nil
 }
+
+func (b *FtypBox) Parse() error {
+	return b.parse()
+}

--- a/atom/moov.go
+++ b/atom/moov.go
@@ -44,6 +44,10 @@ func (b *MoovBox) parse() error {
 		case "mvex":
 			fmt.Println("found mvex")
 			b.IsFragmented = true
+			
+		default:
+			fmt.Printf("found [%s]\n\tSize: %d\n\tStart: %d\n\tFile: %+v\n\n", box.Name, box.Size, box.Start, box.File)
+
 		}
 
 	}

--- a/cmd/mp4info/mp4info.go
+++ b/cmd/mp4info/mp4info.go
@@ -37,49 +37,71 @@ func main() {
 	fmt.Printf("  file Size:    %d\n", f.Size)
 	fmt.Printf("  brands:   %s, %s\n\n", f.Ftyp.MajorBrand, f.Ftyp.CompatibleBrands)
 
-	fmt.Println("Movie:")
 
 	if (f.Moov != nil) {
+		fmt.Println("Movie:")
+
 		fmt.Printf("  duration: %d ms / %d (%s)\n",
 			f.Moov.Mvhd.Duration, f.Moov.Mvhd.Timescale,
 			atom.GetDurationString(f.Moov.Mvhd.Duration, f.Moov.Mvhd.Timescale))
+		fmt.Printf("  fragments:    %t\n", f.IsFragmented)
+		fmt.Printf("  timescale:    %d\n\n", f.Moov.Mvhd.Timescale)
+	
+		fmt.Printf("Found %d Tracks\n\n", len(f.Moov.Traks))
+	
+		for _, trak := range f.Moov.Traks {
+			fmt.Printf("Track %d:\n", trak.Tkhd.TrackID)
+			fmt.Printf("  flags:    %d %s\n", trak.Tkhd.Flags, getFlags(trak.Tkhd.Flags))
+			fmt.Printf("  id:       %d\n", trak.Tkhd.TrackID)
+			fmt.Printf("  type:     %s\n", getHandlerType(trak.Mdia.Hdlr.Handler))
+			fmt.Printf("  duration: %d ms\n", trak.Tkhd.Duration)
+			fmt.Printf("  language: %s\n", trak.Mdia.Mdhd.LanguageString)
+			fmt.Printf("  width:    %d\n", trak.Tkhd.Width/(1<<16))
+			fmt.Printf("  height:   %d\n", trak.Tkhd.Height/(1<<16))
+	
+			fmt.Println("  media:")
+			fmt.Printf("    sample count:   %d\n", trak.Mdia.Minf.Stbl.Stts.SampleCounts[0])
+			fmt.Printf("    timescale:      %d\n", trak.Mdia.Mdhd.Timescale)
+			fmt.Printf("    duration:       %d (media timescale units)\n", trak.Mdia.Mdhd.Duration)
+			fmt.Printf("    duration:       %02.0f (ms)\n", math.Floor(float64(trak.Mdia.Mdhd.Duration)/float64(trak.Mdia.Mdhd.Timescale)*1000))
+	
+			if trak.Tkhd.GetWidth() != 0 || trak.Tkhd.GetHeight() != 0 {
+				fmt.Printf("  display width:         %d\n", trak.Tkhd.GetWidth())
+				fmt.Printf("  display height:        %d\n", trak.Tkhd.GetHeight())
+			}
+	
+			if getHandlerType(trak.Mdia.Hdlr.Handler) == "Video" {
+				sampleCounts := 1000 * trak.Mdia.Minf.Stbl.Stts.SampleCounts[0]
+				durationMs := math.Floor(float64(trak.Mdia.Mdhd.Duration) / float64(trak.Mdia.Mdhd.Timescale) * 1000)
+				fmt.Printf("  frame rate (computed): %.2f\n", float64(sampleCounts)/durationMs)
+			}
+			fmt.Println("")
+		}
 	} else {
-		fmt.Printf("  MOOV atom not found...\n")
-	}
-	fmt.Printf("  fragments:    %t\n", f.IsFragmented)
-	fmt.Printf("  timescale:    %d\n\n", f.Moov.Mvhd.Timescale)
-
-	fmt.Printf("Found %d Tracks\n\n", len(f.Moov.Traks))
-
-	for _, trak := range f.Moov.Traks {
-		fmt.Printf("Track %d:\n", trak.Tkhd.TrackID)
-		fmt.Printf("  flags:    %d %s\n", trak.Tkhd.Flags, getFlags(trak.Tkhd.Flags))
-		fmt.Printf("  id:       %d\n", trak.Tkhd.TrackID)
-		fmt.Printf("  type:     %s\n", getHandlerType(trak.Mdia.Hdlr.Handler))
-		fmt.Printf("  duration: %d ms\n", trak.Tkhd.Duration)
-		fmt.Printf("  language: %s\n", trak.Mdia.Mdhd.LanguageString)
-		fmt.Printf("  width:    %d\n", trak.Tkhd.Width/(1<<16))
-		fmt.Printf("  height:   %d\n", trak.Tkhd.Height/(1<<16))
-
-		fmt.Println("  media:")
-		fmt.Printf("    sample count:   %d\n", trak.Mdia.Minf.Stbl.Stts.SampleCounts[0])
-		fmt.Printf("    timescale:      %d\n", trak.Mdia.Mdhd.Timescale)
-		fmt.Printf("    duration:       %d (media timescale units)\n", trak.Mdia.Mdhd.Duration)
-		fmt.Printf("    duration:       %02.0f (ms)\n", math.Floor(float64(trak.Mdia.Mdhd.Duration)/float64(trak.Mdia.Mdhd.Timescale)*1000))
-
-		if trak.Tkhd.GetWidth() != 0 || trak.Tkhd.GetHeight() != 0 {
-			fmt.Printf("  display width:         %d\n", trak.Tkhd.GetWidth())
-			fmt.Printf("  display height:        %d\n", trak.Tkhd.GetHeight())
+		fmt.Printf("MOOV atom not found...\n\nDumping all boxes found:\n\n")
+	
+		info, err := f.Stat()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return
 		}
-
-		if getHandlerType(trak.Mdia.Hdlr.Handler) == "Video" {
-			sampleCounts := 1000 * trak.Mdia.Minf.Stbl.Stts.SampleCounts[0]
-			durationMs := math.Floor(float64(trak.Mdia.Mdhd.Duration) / float64(trak.Mdia.Mdhd.Timescale) * 1000)
-			fmt.Printf("  frame rate (computed): %.2f\n", float64(sampleCounts)/durationMs)
+	
+		f.Size = info.Size()
+	
+		boxes := atom.ReadBoxes(f, int64(0), f.Size)
+		
+		for _, box := range boxes {
+			switch box.Name {
+				case "ftyp":
+					f.Ftyp = &atom.FtypBox{Box: box}
+					f.Ftyp.Parse()
+					fmt.Printf("[ftyp]\n\tMajor brand: %s\n\tMinor brand: %d\n\tCompatible brands: %+v\n\n",
+						f.Ftyp.MajorBrand, f.Ftyp.MinorVersion, f.Ftyp.CompatibleBrands)
+				default:
+					fmt.Printf("[%s]\n\tSize: %d\n\tStart: %d\n\tFile: %+v\n\n", box.Name, box.Size, box.Start, box.File)
+			}
 		}
-		fmt.Println("")
 	}
-
 }
 
 func getHandlerType(handler string) string {

--- a/cmd/mp4info/mp4info.go
+++ b/cmd/mp4info/mp4info.go
@@ -25,7 +25,7 @@ func main() {
 	}
 
 	f, err := mp4.Open(input)
-	if err != nil {
+ 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return
 	}
@@ -38,9 +38,14 @@ func main() {
 	fmt.Printf("  brands:   %s, %s\n\n", f.Ftyp.MajorBrand, f.Ftyp.CompatibleBrands)
 
 	fmt.Println("Movie:")
-	fmt.Printf("  duration: %d ms / %d (%s)\n",
-		f.Moov.Mvhd.Duration, f.Moov.Mvhd.Timescale,
-		atom.GetDurationString(f.Moov.Mvhd.Duration, f.Moov.Mvhd.Timescale))
+
+	if (f.Moov != nil) {
+		fmt.Printf("  duration: %d ms / %d (%s)\n",
+			f.Moov.Mvhd.Duration, f.Moov.Mvhd.Timescale,
+			atom.GetDurationString(f.Moov.Mvhd.Duration, f.Moov.Mvhd.Timescale))
+	} else {
+		fmt.Printf("  MOOV atom not found...\n")
+	}
 	fmt.Printf("  fragments:    %t\n", f.IsFragmented)
 	fmt.Printf("  timescale:    %d\n\n", f.Moov.Mvhd.Timescale)
 


### PR DESCRIPTION
I've basically just changed the code a bit on the `mp4info` CLI to show all atoms/boxes that could be found even if the `MOOV` atom is not present.

This is a very quick & dirty hack, not optimised whatsoever; I'm just a humble amateur programmer and used lots of redundant copy & pasting instead of rewriting the code in an efficient manner!