### PR TITLE
parse custom uuid atom

### DIFF
--- a/atom/box.go
+++ b/atom/box.go
@@ -64,6 +64,10 @@ func (m *Mp4Reader) ReadBoxAt(offset int64) (boxSize uint32, boxType string) {
 		return 0, ""
 	}
 	boxSize = binary.BigEndian.Uint32(buf[0:4])
+	// check malformed data
+	if offset+int64(boxSize) > m.Size {
+		return 0, ""
+	}
 	boxType = string(buf[4:8])
 	return
 }

--- a/atom/box.go
+++ b/atom/box.go
@@ -2,14 +2,14 @@ package atom
 
 import (
 	"encoding/binary"
-	"fmt"
 	"io"
 	"os"
 )
 
 const (
 	// BoxHeaderSize Size of box header.
-	BoxHeaderSize = int64(8)
+	BoxHeaderSize = 8
+	UuidSize      = 16
 )
 
 // Mp4Reader defines an mp4 reader structure.
@@ -18,6 +18,7 @@ type Mp4Reader struct {
 	Ftyp   *FtypBox
 	Moov   *MoovBox
 	Mdat   *MdatBox
+	Uuids  []*UuidBox
 	Size   int64
 
 	IsFragmented bool
@@ -29,7 +30,6 @@ func (m *Mp4Reader) Parse() error {
 		if ofile, ok := m.Reader.(*os.File); ok {
 			info, err := ofile.Stat()
 			if err != nil {
-				fmt.Fprintln(os.Stderr, err)
 				return err
 			}
 			m.Size = info.Size()
@@ -41,14 +41,17 @@ func (m *Mp4Reader) Parse() error {
 		switch box.Name {
 		case "ftyp":
 			m.Ftyp = &FtypBox{Box: box}
-			m.Ftyp.parse()
+			_ = m.Ftyp.parse()
 		case "mdat":
 			m.Mdat = &MdatBox{Box: box}
 		case "moov":
 			m.Moov = &MoovBox{Box: box}
-			m.Moov.parse()
-
+			_ = m.Moov.parse()
 			m.IsFragmented = m.Moov.IsFragmented
+		case "uuid":
+			uuidBox := &UuidBox{Box: box}
+			_ = uuidBox.parse()
+			m.Uuids = append(m.Uuids, uuidBox)
 		}
 	}
 	return nil
@@ -57,16 +60,18 @@ func (m *Mp4Reader) Parse() error {
 // ReadBoxAt reads a box from an offset.
 func (m *Mp4Reader) ReadBoxAt(offset int64) (boxSize uint32, boxType string) {
 	buf := m.ReadBytesAt(BoxHeaderSize, offset)
+	if len(buf) < BoxHeaderSize {
+		return 0, ""
+	}
 	boxSize = binary.BigEndian.Uint32(buf[0:4])
 	boxType = string(buf[4:8])
-	return boxSize, boxType
+	return
 }
 
 // ReadBytesAt reads a box at n and offset.
 func (m *Mp4Reader) ReadBytesAt(n int64, offset int64) (word []byte) {
 	buf := make([]byte, n)
-	if _, error := m.Reader.ReadAt(buf, offset); error != nil {
-		fmt.Println(error)
+	if _, err := m.Reader.ReadAt(buf, offset); err != nil {
 		return
 	}
 	return buf
@@ -90,14 +95,15 @@ func (b *Box) ReadBoxData() []byte {
 func readBoxes(m *Mp4Reader, start int64, n int64) (l []*Box) {
 	for offset := start; offset < start+n; {
 		size, name := m.ReadBoxAt(offset)
-
+		if size == 0 || len(name) == 0 {
+			break
+		}
 		b := &Box{
-			Name:   string(name),
+			Name:   name,
 			Size:   int64(size),
 			Reader: m,
 			Start:  offset,
 		}
-
 		l = append(l, b)
 		offset += int64(size)
 	}

--- a/atom/ftyp.go
+++ b/atom/ftyp.go
@@ -2,6 +2,7 @@ package atom
 
 import (
 	"encoding/binary"
+	"errors"
 )
 
 // FtypBox - File Type Box
@@ -18,6 +19,9 @@ type FtypBox struct {
 
 func (b *FtypBox) parse() error {
 	data := b.ReadBoxData()
+	if len(data) < 8 {
+		return errors.New("not enough data")
+	}
 	b.MajorBrand, b.MinorVersion = string(data[0:4]), binary.BigEndian.Uint32(data[4:8])
 	if len(data) > 8 {
 		for i := 8; i < len(data); i += 4 {

--- a/atom/uuid.go
+++ b/atom/uuid.go
@@ -1,0 +1,23 @@
+package atom
+
+import (
+	"errors"
+)
+
+// UuidBox - Uuid Box
+// Box Type: uuid
+type UuidBox struct {
+	*Box
+	Uuid []byte
+	Data []byte
+}
+
+func (b *UuidBox) parse() error {
+	data := b.ReadBoxData()
+	if len(data) < UuidSize {
+		return errors.New("not enough data")
+	}
+	b.Uuid = data[:UuidSize]
+	b.Data = data[UuidSize:]
+	return nil
+}

--- a/cmd/mp4info/mp4info.go
+++ b/cmd/mp4info/mp4info.go
@@ -62,7 +62,6 @@ func main() {
 
 	f, err := mp4.Open(input)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
 		return
 	}
 

--- a/mp4.go
+++ b/mp4.go
@@ -2,7 +2,6 @@ package mp4
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"os"
 
@@ -13,7 +12,6 @@ import (
 func Open(path string) (f *atom.Mp4Reader, err error) {
 	file, err := os.Open(path)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
 		return nil, err
 	}
 


### PR DESCRIPTION
- add `uuid` Box type
- remove `fmt.Print`, API already return error
- handle some invalid data when parsing